### PR TITLE
V2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 (2023-09-15)
+
+- da22d3e fix: relative path calc on Windows [#13](https://github.com/vite-plugin/vite-plugin-native/issues/13)
+
 ## 2.2.1 (2023-06-29)
 
 - 548fedb fix: avoid Vite built-in alias

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-native",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Supports Node/Electron C/C++ native addons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,8 @@ export default function native(options: NativeOptions): Plugin {
             return
           }
 
-          const nativeFilename = path.join(output, source + NativeExt)
-          const interopFilename = path.join(output, source + InteropExt)
+          const nativeFilename = path.posix.join(output, source + NativeExt)
+          const interopFilename = path.posix.join(output, source + InteropExt)
 
           if (!nativesMap.get(source)) {
             ensureDir(path.dirname(interopFilename))
@@ -279,7 +279,7 @@ async function forceCopyNativeFilesIfUnbuilt(
     .some((file) => fs.existsSync(path.join(nativeOutput, file)))
 
   if (!exists) {
-    const nativeDest = path.join(nativeNodeModules, nativeName)
+    const nativeDest = path.posix.join(nativeNodeModules, nativeName)
     copy(nativeRoot, nativeDest)
 
     const dependencies = await flatDependencies(nativeRoot)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export async function getDependenciesNatives(root = process.cwd()): Promise<Map<
       for (const dep of deps) {
         if (natives.has(dep)) continue
 
-        const depPath = path.join(node_modules_path, dep)
+        const depPath = path.posix.join(node_modules_path, dep)
         const nativeFiles = await globNativeFiles(depPath)
 
         if (nativeFiles.length) {


### PR DESCRIPTION
## 2.2.2 (2023-09-15)

- da22d3e fix: relative path calc on Windows [#13](https://github.com/vite-plugin/vite-plugin-native/issues/13)
